### PR TITLE
added default for unknown language

### DIFF
--- a/api/PYtranslator.py
+++ b/api/PYtranslator.py
@@ -17,7 +17,7 @@ except:
     except:
         from .constant import LANGUAGES, DEFAULT_SERVICE_URLS
 
-LANGUAGES.set_default('keyerror')
+LANGUAGES.setdefault('keyerror')
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/api/PYtranslator.py
+++ b/api/PYtranslator.py
@@ -17,7 +17,8 @@ except:
     except:
         from .constant import LANGUAGES, DEFAULT_SERVICE_URLS
 
-    
+LANGUAGES.set_default('keyerror')
+
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 

--- a/api/PYtranslator.py
+++ b/api/PYtranslator.py
@@ -17,7 +17,6 @@ except:
     except:
         from .constant import LANGUAGES, DEFAULT_SERVICE_URLS
 
-LANGUAGES.setdefault('keyerror')
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -210,7 +209,7 @@ class google_translator:
                         detect_lang = response[0][2]
                     except Exception:
                         raise Exception
-                    return [detect_lang, LANGUAGES[detect_lang.lower()]]
+                    return [detect_lang, LANGUAGES.get(detect_lang.lower())]
             r.raise_for_status()
         except requests.exceptions.HTTPError as e:
             log.debug(str(e))


### PR DESCRIPTION
The LANGUAGES dictionary was missing some languages like Akkadian, etc which were detected during the detect_language run. So, I changed languages[key] to languages.get(key) to remove the KeyError and the detect_language would return ['AK',False] instead of keyerror on such problems.